### PR TITLE
update popstart to go up to 1000 animals

### DIFF
--- a/inst/shiny/CaribouBC/ui.R
+++ b/inst/shiny/CaribouBC/ui.R
@@ -6,7 +6,7 @@ dashboardPage(
       min = 1, max = 50, value = 20, step = 1
     ),
     sliderInput("popstart", "Initial population size",
-      min = 1, max = 200, value = 100, step = 1
+      min = 1, max = 1000, value = 100, step = 1
     ),
     bsTooltip("tmax",
       "Number of years in which the caribou population is forecasted. Default set, but the user can change the value by slider."),


### PR DESCRIPTION
Staff request to be able to model populations > 200 animals; changing popstart to 1000 animals to allow this functionality. 